### PR TITLE
Add basic user authentication collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This repository provides a dockerized Payload CMS setup with an AI enrichment pi
    docker compose up -d
    ```
 2. Access the admin panel at `http://localhost:3000/admin`.
+3. When prompted, create the initial user by entering an email and password.
 
 ## Apache Reverse Proxy Example
 ```apache

--- a/payload/collections/User.js
+++ b/payload/collections/User.js
@@ -1,0 +1,17 @@
+module.exports = {
+  slug: 'users',
+  auth: true,
+  fields: [
+    {
+      name: 'email',
+      type: 'email',
+      required: true,
+      unique: true,
+    },
+    {
+      name: 'password',
+      type: 'password',
+      required: true,
+    },
+  ],
+};

--- a/payload/payload.config.js
+++ b/payload/payload.config.js
@@ -1,6 +1,7 @@
 require('dotenv').config();
 const MediaAsset = require('./collections/MediaAsset');
 const Tag = require('./collections/Tag');
+const User = require('./collections/User');
 
 module.exports = {
   serverURL: `http://localhost:${process.env.PORT || 3000}`,
@@ -8,7 +9,7 @@ module.exports = {
     staticURL: '/uploads',
     staticDir: process.env.UPLOAD_DIR,
   },
-  collections: [MediaAsset, Tag],
+  collections: [User, MediaAsset, Tag],
   admin: {
     user: 'users',
   },


### PR DESCRIPTION
## Summary
- create `payload/collections/User.js` to enable authentication
- register users collection in `payload.config.js`
- mention creating the first user in the README

## Testing
- `node -c payload/collections/User.js`
- `node -c payload/payload.config.js`

------
https://chatgpt.com/codex/tasks/task_b_68428f3f9c50832d9266c167e4da7154