### PR TITLE
Fix package main path

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "iddtw",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "payload/server.js",
   "scripts": {
     "start": "node payload/server.js"
   },


### PR DESCRIPTION
## Summary
- correct `main` path to match the server entry

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68429cddefcc832d9ba1ef3652d3b8bd