### PR TITLE
Fix duplicate install step

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ This repository provides a dockerized Payload CMS setup with an AI enrichment pi
    npm install       # or `pnpm install`
    cp .env.example .env
    # edit .env with your secrets
-   npm install
    docker compose up -d
    ```
 2. Access the admin panel at `http://localhost:3000/admin`.


### PR DESCRIPTION
## Summary
- remove duplicate `npm install` from README

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68429ccabcec832dbb11a39c8c0ecd1d