### PR TITLE
Handle missing OpenAI key

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ The `.env` file includes:
 - `UPLOAD_DIR` - directory for uploaded files
 - `PORT` - port for the Payload server
 
+If `OPENAI_API_KEY` is not provided, the AI enrichment service returns default values without contacting OpenAI (titles and alt text will be `null` and tags will be an empty array).
+
 ## Apache Reverse Proxy Example
 ```apache
 <VirtualHost *:443>

--- a/services/ai/aiService.js
+++ b/services/ai/aiService.js
@@ -3,10 +3,16 @@ require('dotenv').config();
 const { Configuration, OpenAIApi } = require('openai');
 
 // Configure the OpenAI client. Using the SDK keeps our calls concise.
-const configuration = new Configuration({
-  apiKey: process.env.OPENAI_API_KEY,
-});
-const openai = new OpenAIApi(configuration);
+const openAIKey = process.env.OPENAI_API_KEY;
+let openai;
+if (openAIKey) {
+  const configuration = new Configuration({
+    apiKey: openAIKey,
+  });
+  openai = new OpenAIApi(configuration);
+} else {
+  console.warn('OPENAI_API_KEY not set. AI enrichment disabled.');
+}
 
 const MAX_TOKENS = parseInt(process.env.OPENAI_MAX_TOKENS || '60', 10);
 const RETRY_LIMIT = parseInt(process.env.OPENAI_RETRIES || '3', 10);
@@ -14,6 +20,9 @@ const RETRY_LIMIT = parseInt(process.env.OPENAI_RETRIES || '3', 10);
 // Wrapper around OpenAI chat completion API. Returns the assistant's final text
 // response for convenience.
 async function callChat(messages, retries = RETRY_LIMIT) {
+  if (!openai) {
+    return '';
+  }
   for (let attempt = 1; attempt <= retries; attempt++) {
     try {
       const res = await openai.createChatCompletion({
@@ -36,12 +45,14 @@ async function callChat(messages, retries = RETRY_LIMIT) {
 
 // Generate a short human readable title for a media file using its name as a hint.
 async function generateTitle(filename) {
+  if (!openai) return null;
   const prompt = `You are a content metadata generator. Given a file name, create a short, professional title. File: ${filename}`;
   return await callChat([{ role: 'user', content: prompt }]);
 }
 
 // Generate accessible alt text describing the file's content.
 async function generateAltText(filename) {
+  if (!openai) return null;
   const prompt = `You are an alt text generator. Write ADA-compliant alt text for this file: ${filename}`;
   return await callChat([{ role: 'user', content: prompt }]);
 }
@@ -50,6 +61,7 @@ async function generateAltText(filename) {
 // prompt instructs the model to provide a comma or newline separated list which
 // we then split into an array.
 async function generateTags(filename) {
+  if (!openai) return [];
   const prompt = `You are a tagging system. Generate 5-10 highly relevant search tags describing this media file: ${filename}`;
   const tagsString = await callChat([{ role: 'user', content: prompt }]);
   return tagsString.split(/,|\n/).map(t => t.trim()).filter(Boolean);


### PR DESCRIPTION
## Summary
- guard aiService against missing `OPENAI_API_KEY`
- explain fallback behavior in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6842a030bbf0832db0750bb28faac997