### PR TITLE
Fix SERVER_URL env for docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - UPLOAD_DIR=${UPLOAD_DIR}
       - PORT=${PORT}
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - SERVER_URL=${SERVER_URL}
     ports:
       - "3000:3000"
     command: sh -c "node /app/payload/server.js"


### PR DESCRIPTION
## Summary
- add `SERVER_URL` variable to `docker-compose.yml`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6842a92eaac4832db7300416176dc1fc