### PR TITLE
Fix lint script for ESLint 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "payload/server.js",
   "scripts": {
     "start": "node payload/server.js",
-    "lint": "eslint payload services"
+    "lint": "eslint -c .eslintrc.json payload services"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- fix `npm run lint` so it works with the project ESLint version

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6842ba8cf5f8832d8f003e32812dba67