### PR TITLE
Restrict collection write access

### DIFF
--- a/payload/collections/MediaAsset.js
+++ b/payload/collections/MediaAsset.js
@@ -14,6 +14,14 @@ module.exports = {
   // Enable createdAt/updatedAt timestamps
   timestamps: true,
 
+  // Restrict writes to authenticated users while allowing public read access
+  access: {
+    read: () => true,
+    create: ({ req }) => !!req.user,
+    update: ({ req }) => !!req.user,
+    delete: ({ req }) => !!req.user,
+  },
+
   // Configure Payload's built-in upload handler
   upload: {
     staticDir: process.env.UPLOAD_DIR,

--- a/payload/collections/Tag.js
+++ b/payload/collections/Tag.js
@@ -8,6 +8,14 @@ module.exports = {
 
   timestamps: true,
 
+  // Allow public read access while limiting writes to authenticated users
+  access: {
+    read: () => true,
+    create: ({ req }) => !!req.user,
+    update: ({ req }) => !!req.user,
+    delete: ({ req }) => !!req.user,
+  },
+
   fields: [
     {
       // Human readable name of the tag


### PR DESCRIPTION
## Summary
- restrict modification operations for MediaAsset and Tag collections to authenticated users

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6843fc6d43f4832d8c65e05164781898