### PR TITLE
Fix user collection duplicates

### DIFF
--- a/payload/collections/User.js
+++ b/payload/collections/User.js
@@ -3,22 +3,11 @@ module.exports = {
   slug: 'users',
 
   // Enable built-in auth functionality. Payload will automatically add
-  // login endpoints and password hashing.
+  // login endpoints and password hashing along with the required email
+  // and password fields.
   auth: true,
 
-  fields: [
-    {
-      // Administrator email address used for login
-      name: 'email',
-      type: 'email',
-      required: true,
-      unique: true,
-    },
-    {
-      // Hashed password field handled by Payload
-      name: 'password',
-      type: 'password',
-      required: true,
-    },
-  ],
+  // No additional fields are necessary. Payload manages `email` and
+  // `password` automatically when auth is enabled.
+  fields: [],
 };


### PR DESCRIPTION
## Summary
- remove email and password fields from user collection

## Testing
- `npm run lint` *(fails: A config object is using the "env" key, which is not supported in flat config system)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68467b1d2cc8832d8f26b0fb277f6d5c