### PR TITLE
Fix ESM imports for Payload server

### DIFF
--- a/payload/collections/MediaAsset.js
+++ b/payload/collections/MediaAsset.js
@@ -1,7 +1,6 @@
 // Utilities for working with file paths and generating URL friendly slugs.
 const path = require('path');
 const { slugify } = require('transliteration');
-const payload = require('payload');
 
 // Custom AI helpers used to enrich uploaded media with metadata. The service
 // wraps OpenAI calls to produce titles, alt text and tags for a file.
@@ -135,8 +134,12 @@ module.exports = {
             },
           });
         } catch (err) {
-          if (payload.logger && typeof payload.logger.error === 'function') {
-            payload.logger.error('AI enrichment failed', err);
+          if (
+            req.payload &&
+            req.payload.logger &&
+            typeof req.payload.logger.error === 'function'
+          ) {
+            req.payload.logger.error('AI enrichment failed', err);
           } else {
             console.error('AI enrichment failed', err);
           }

--- a/payload/server.js
+++ b/payload/server.js
@@ -3,10 +3,9 @@ require('dotenv').config();
 
 const express = require('express');
 const path = require('path');
-// When using Payload with CommonJS, the default export lives on the `default`
-// property. Without accessing `.default`, `payload.init` would be undefined and
-// the server would crash on startup.
-const payload = require('payload').default;
+// Dynamically import the ESM build of Payload. Using a dynamic import allows
+// this file to remain CommonJS while loading the module.
+const loadPayload = async () => (await import('payload')).default;
 
 // Create the Express app which Payload will hook into.
 const app = express();
@@ -17,6 +16,7 @@ const app = express();
 app.set('trust proxy', 1);
 
 const start = async () => {
+  const payload = await loadPayload();
   // Ensure the config file path is set so Payload knows where to load its
   // configuration from when running directly via Node.
   const configPath = path.join(__dirname, 'payload.config.js');


### PR DESCRIPTION
## Summary
- load Payload dynamically in server.js
- remove direct `require('payload')` from MediaAsset collection
- use `req.payload.logger` for AI enrichment error logging

## Testing
- `npm run lint` *(fails: A config object is using the "env" key, which is not supported in flat config system)*

------
https://chatgpt.com/codex/tasks/task_b_684867cc795c832d82acab825b1aefa5